### PR TITLE
chore: add .claudeignore

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,22 @@
+# Node
+node_modules/
+dist/
+build/
+out/
+.next/
+.nuxt/
+.svelte-kit/
+coverage/
+*.min.js
+*.min.css
+.turbo/
+
+# Secrets & environment
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+*.p12
+*.pfx
+secrets/


### PR DESCRIPTION
Adds a `.claudeignore` tailored for **node**. Keeps secrets and build artifacts out of Claude's context.